### PR TITLE
fix: children with same key error cause by row, lazyloading and infinite

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -85,7 +85,7 @@ const getSlideStyle = spec => {
   return style;
 };
 
-const getKey = (child, fallbackKey) => child.key || fallbackKey;
+const getKey = (child, fallbackKey) => child.key || 'fallback-' + fallbackKey;
 
 const renderSlides = spec => {
   let key;


### PR DESCRIPTION
To fix this issue : https://github.com/akiran/react-slick/issues/1987